### PR TITLE
Improve GRADLE build Performance

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -351,3 +351,11 @@ artifacts {
     archives(binaryRelease('buildStartJar', 'Start', 'org.gsc.Start'),
             binaryRelease('buildKeystoreFactoryJar', 'KeystoreFactory', 'org.gsc.utils.KeystoreFactory'))
 }
+
+allprojects {
+    tasks.withType(JavaCompile).configureEach {
+        options.fork = true
+        options.incremental = true
+    }
+
+}


### PR DESCRIPTION

[Compiler daemon](https://docs.gradle.org/current/userguide/performance.html#compiler_daemon). The Gradle Java plugin allows you to run the compiler as a separate process by setting `options.fork = true`. This feature can lead to much less garbage collection and make Gradle’s infrastructure faster. This project has more than 1000 source files. We can consider enabling this feature.

[Incremental compilation](https://docs.gradle.org/current/userguide/performance.html#incremental_compilation). Gradle recompile only the classes that were affected by a change. This feature is the default since Gradle 4.10. For an older versions, we can activate it by setting `options.incremental = true`.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
